### PR TITLE
Allow Configuration of BigInt Serialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 #[cfg(all(feature = "json", not(feature = "js")))]
 pub use gloo_utils::format::JsValueSerdeExt;
+#[cfg(feature = "js")]
+pub use serde_wasm_bindgen;
 pub use tsify_macros::*;
 #[cfg(feature = "wasm-bindgen")]
 use wasm_bindgen::{JsCast, JsValue};
@@ -9,6 +11,7 @@ use wasm_bindgen::{JsCast, JsValue};
 pub struct SerializationConfig {
     pub missing_as_null: bool,
     pub hashmap_as_object: bool,
+    pub large_number_types_as_bigints: bool,
 }
 
 pub trait Tsify {
@@ -19,6 +22,7 @@ pub trait Tsify {
     const SERIALIZATION_CONFIG: SerializationConfig = SerializationConfig {
         missing_as_null: false,
         hashmap_as_object: false,
+        large_number_types_as_bigints: false,
     };
 
     #[cfg(all(feature = "json", not(feature = "js")))]
@@ -48,7 +52,8 @@ pub trait Tsify {
         let config = <Self as Tsify>::SERIALIZATION_CONFIG;
         let serializer = serde_wasm_bindgen::Serializer::new()
             .serialize_missing_as_null(config.missing_as_null)
-            .serialize_maps_as_objects(config.hashmap_as_object);
+            .serialize_maps_as_objects(config.hashmap_as_object)
+            .serialize_large_number_types_as_bigints(config.large_number_types_as_bigints);
         self.serialize(&serializer).map(JsCast::unchecked_from_js)
     }
 

--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -24,6 +24,7 @@ const _: () = {
         const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
             missing_as_null: false,
             hashmap_as_object: false,
+            large_number_types_as_bigints: false,
         };
     }
     #[wasm_bindgen(typescript_custom_section)]

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -25,6 +25,7 @@ const _: () = {
         const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
             missing_as_null: false,
             hashmap_as_object: false,
+            large_number_types_as_bigints: false,
         };
     }
     #[wasm_bindgen(typescript_custom_section)]

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -22,6 +22,7 @@ const _: () = {
         const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
             missing_as_null: false,
             hashmap_as_object: false,
+            large_number_types_as_bigints: false,
         };
     }
     #[wasm_bindgen(typescript_custom_section)]
@@ -96,6 +97,7 @@ const _: () = {
         const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
             missing_as_null: false,
             hashmap_as_object: false,
+            large_number_types_as_bigints: false,
         };
     }
     #[wasm_bindgen(typescript_custom_section)]

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -38,4 +38,19 @@ fn test_transparent() {
             }"
         }
     );
+
+    #[derive(Tsify)]
+    #[tsify(large_number_types_as_bigints)]
+    struct BigNumber {
+        a: u64,
+    }
+
+    assert_eq!(
+        BigNumber::DECL,
+        indoc! {"
+            export interface BigNumber {
+                a: bigint;
+            }"
+        }
+    )
 }

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -14,6 +14,7 @@ pub struct TypeGenerationConfig {
     pub type_suffix: Option<String>,
     pub missing_as_null: bool,
     pub hashmap_as_object: bool,
+    pub large_number_types_as_bigints: bool,
 }
 impl TypeGenerationConfig {
     pub fn format_name(&self, mut name: String) -> String {
@@ -108,7 +109,20 @@ impl TsifyContainerAttrs {
                     return Ok(());
                 }
 
-                Err(meta.error("unsupported tsify attribute, expected one of `into_wasm_abi`, `from_wasm_abi`, `namespace`, 'type_prefix', 'type_suffix', 'missing_as_null', 'hashmap_as_object'"))
+                if meta.path.is_ident("large_number_types_as_bigints") {
+                    if attrs.ty_config.large_number_types_as_bigints {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    if cfg!(not(feature = "js")) {
+                        return Err(meta.error(
+                            "#[tsify(large_number_types_as_bigints)] requires the `js` feature",
+                        ));
+                    }
+                    attrs.ty_config.large_number_types_as_bigints = true;
+                    return Ok(());
+                }
+
+                Err(meta.error("unsupported tsify attribute, expected one of `into_wasm_abi`, `from_wasm_abi`, `namespace`, 'type_prefix', 'type_suffix', 'missing_as_null', 'hashmap_as_object', 'large_number_types_as_bigints'"))
             })?;
         }
 

--- a/tsify-macros/src/typescript.rs
+++ b/tsify-macros/src/typescript.rs
@@ -301,8 +301,16 @@ impl TsType {
         };
 
         match name.as_str() {
-            "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize"
+            "u8" | "u16" | "u32" | "i8" | "i16" | "i32"
             | "f64" | "f32" => Self::NUMBER,
+
+            "usize" | "isize" | "u64" | "i64" => {
+                if cfg!(feature = "js") && config.large_number_types_as_bigints {
+                    Self::BIGINT
+                } else {
+                    Self::NUMBER
+                }
+            }
 
             "u128" | "i128" => {
                 if cfg!(feature = "js") {

--- a/tsify-macros/src/wasm_bindgen.rs
+++ b/tsify-macros/src/wasm_bindgen.rs
@@ -44,6 +44,7 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
     
     let missing_as_null = attrs.ty_config.missing_as_null;
     let hashmap_as_object = attrs.ty_config.hashmap_as_object;
+    let large_number_types_as_bigints = attrs.ty_config.large_number_types_as_bigints;
 
     quote! {
         #[automatically_derived]
@@ -66,9 +67,10 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
             impl #impl_generics Tsify for #ident #ty_generics #where_clause {
                 type JsType = JsType;
                 const DECL: &'static str = #decl_str;
-                const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig { 
+                const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
                     missing_as_null: #missing_as_null,
                     hashmap_as_object: #hashmap_as_object,
+                    large_number_types_as_bigints: #large_number_types_as_bigints,
                 };
             }
 


### PR DESCRIPTION
Hi !

I saw all your PRs in tsify repo and I was sad to see you got no feedback as I made one built on yours.

I saw you made a branch to merge all your work on tsify in a "modyfi" branch, I find it to be a really good idea to move forward as there is no good alternative to tsify for my need.

So I share my branch here, I would be really happy to have your feedback. This is taken from madonoharu/tsify#34 , it allows to specify that you want big sized number in rust to be exported as bigint in JS.

Thank you for your time !